### PR TITLE
LineageParts: Do not restore keydisabler state at boot

### DIFF
--- a/src/org/lineageos/lineageparts/BootReceiver.java
+++ b/src/org/lineageos/lineageparts/BootReceiver.java
@@ -33,11 +33,11 @@ public class BootReceiver extends BroadcastReceiver {
 
         if (!hasRestoredTunable(ctx)) {
             /* Restore the hardware tunable values */
-            ButtonSettings.restoreKeyDisabler(ctx);
+            /* ButtonSettings.restoreKeyDisabler(ctx); */
             setRestoredTunable(ctx);
         }
 
-        ButtonSettings.restoreKeyDisabler(ctx);
+        /* ButtonSettings.restoreKeyDisabler(ctx); */
         ButtonSettings.restoreKeySwapper(ctx);
         TouchscreenGestureSettings.restoreTouchscreenGestureStates(ctx);
 


### PR DESCRIPTION
Otherwise it would overwrite the user's preference set via the "Disable HW keys" setting.